### PR TITLE
fix: remove expired peer metrics after sync

### DIFF
--- a/internal/adapters/database.go
+++ b/internal/adapters/database.go
@@ -1370,6 +1370,18 @@ func (r *SqlRepo) UpdatePeerStatus(
 		}
 
 		err := r.db.WithContext(ctx).Transaction(func(tx *gorm.DB) error {
+			// CRITICAL: Check if peer still exists before attempting to update its status
+			// If peer was deleted (e.g., by master node), skip update to avoid recreating orphaned records
+			var peerExists int64
+			if err := tx.Model(&domain.Peer{}).Where("identifier = ?", id).Count(&peerExists).Error; err != nil {
+				return err
+			}
+			if peerExists == 0 {
+				// Peer was deleted - don't try to update or create peer_status
+				slog.Debug("skipping peer status update for already deleted peer", "peer", id)
+				return nil // success - nothing to do
+			}
+
 			in, err := r.getOrCreatePeerStatus(tx, id)
 			if err != nil {
 				return err // return any error will roll back
@@ -1426,18 +1438,6 @@ func (r *SqlRepo) UpdatePeerStatus(
 				slog.Debug("clearing peer ownership on offline transition",
 					"peer", id, "old_owner", in.OwnerNodeId)
 				in.OwnerNodeId = ""
-			}
-
-			// CRITICAL: Verify peer still exists before updating its status
-			// If peer was deleted, skip status update to avoid recreating orphaned peer_status records
-			// This prevents metrics for deleted peers from being recreated
-			var peerExists int64
-			if err := tx.Model(&domain.Peer{}).Where("identifier = ?", id).Count(&peerExists).Error; err != nil {
-				return err
-			}
-			if peerExists == 0 {
-				slog.Debug("skipping peer status update for deleted peer", "peer", id)
-				return nil // peer was deleted, don't update its status
 			}
 
 			err = r.upsertPeerStatus(tx, in)

--- a/internal/app/wireguard/statistics.go
+++ b/internal/app/wireguard/statistics.go
@@ -430,10 +430,19 @@ func (c *StatisticsCollector) updatePeerFromWireGuard(ctx context.Context, iface
 }
 
 func (c *StatisticsCollector) markPeerDisconnected(ctx context.Context, peerID domain.PeerIdentifier) {
+	// Check if peer still exists - skip if already deleted (e.g., by master node)
+	// This prevents trying to mark deleted peers as disconnected on non-master nodes
+	_, err := c.db.GetPeer(ctx, peerID)
+	if err != nil {
+		// Peer was deleted - no need to mark disconnected
+		slog.Debug("skipping markPeerDisconnected for deleted peer", "peer", peerID)
+		return
+	}
+
 	// Capture the updated status and peer for publishing the event
 	var updatedStatus domain.PeerStatus
 
-	err := c.db.UpdatePeerStatus(ctx, peerID,
+	err = c.db.UpdatePeerStatus(ctx, peerID,
 		func(p *domain.PeerStatus) (*domain.PeerStatus, error) {
 			// Set peer as disconnected regardless of current state
 			// We need to clean up metrics even if peer is already marked false

--- a/internal/app/wireguard/wireguard_interfaces.go
+++ b/internal/app/wireguard/wireguard_interfaces.go
@@ -258,7 +258,7 @@ func (m Manager) RestoreInterfaceState(
 						"attempt", attempt+1,
 						"max_attempts", maxRetries+1,
 						"error", saveErr)
-					
+
 					// Exponential backoff with max 5 seconds
 					time.Sleep(retryDelay)
 					nextDelay := retryDelay * 2
@@ -308,7 +308,7 @@ func (m Manager) RestoreInterfaceState(
 						"attempt", attempt+1,
 						"max_attempts", maxRetries+1,
 						"error", restoreErr)
-					
+
 					// Exponential backoff with max 5 seconds
 					time.Sleep(retryDelay)
 					nextDelay := retryDelay * 2

--- a/internal/app/wireguard/wireguard_peers.go
+++ b/internal/app/wireguard/wireguard_peers.go
@@ -330,25 +330,25 @@ func (m Manager) CreatePeer(ctx context.Context, peer *domain.Peer) (*domain.Pee
 		}
 
 		// Check if this is a unique constraint violation (IP already taken)
-		if strings.Contains(saveErr.Error(), "Duplicate entry") || 
-		   strings.Contains(saveErr.Error(), "UNIQUE constraint") ||
-		   strings.Contains(saveErr.Error(), "unique constraint") {
+		if strings.Contains(saveErr.Error(), "Duplicate entry") ||
+			strings.Contains(saveErr.Error(), "UNIQUE constraint") ||
+			strings.Contains(saveErr.Error(), "unique constraint") {
 			if attempt < maxRetries {
 				slog.DebugContext(ctx, "IP allocation conflict - retrying with next IP",
 					"peer_id", peer.Identifier,
 					"attempt", attempt+1,
 					"max_retries", maxRetries)
-				
+
 				// Get fresh IP addresses for all subnets
 				iface, ifaceErr := m.db.GetInterface(ctx, peer.InterfaceIdentifier)
 				if ifaceErr != nil {
 					return nil, fmt.Errorf("failed to get interface after IP conflict: %w", ifaceErr)
 				}
-				
+
 				// Allocate next IPs using sequence-based approach (no locks)
 				networks, _ := domain.CidrsFromString(iface.PeerDefNetworkStr)
 				newIps := make([]domain.Cidr, 0, len(networks))
-				
+
 				for _, network := range networks {
 					nextIP, ipErr := m.db.GetNextPeerIPForSubnet(ctx, network)
 					if ipErr != nil {
@@ -356,16 +356,16 @@ func (m Manager) CreatePeer(ctx context.Context, peer *domain.Peer) (*domain.Pee
 					}
 					newIps = append(newIps, nextIP)
 				}
-				
+
 				peer.Interface.Addresses = newIps
 				continue
 			}
 		}
-		
+
 		// For other errors, return immediately
 		return nil, fmt.Errorf("creation failure: %w", saveErr)
 	}
-	
+
 	if saveErr != nil {
 		return nil, fmt.Errorf("creation failure: max retries exceeded: %w", saveErr)
 	}
@@ -422,26 +422,26 @@ func (m Manager) CreateMultiplePeers(
 			}
 
 			// Check if this is a unique constraint violation (IP already taken)
-			if strings.Contains(saveErr.Error(), "Duplicate entry") || 
-			   strings.Contains(saveErr.Error(), "UNIQUE constraint") ||
-			   strings.Contains(saveErr.Error(), "unique constraint") {
+			if strings.Contains(saveErr.Error(), "Duplicate entry") ||
+				strings.Contains(saveErr.Error(), "UNIQUE constraint") ||
+				strings.Contains(saveErr.Error(), "unique constraint") {
 				if attempt < maxRetries {
 					slog.DebugContext(ctx, "IP allocation conflict in CreateMultiplePeers - retrying with next IP",
 						"peer_id", freshPeer.Identifier,
 						"user_id", id,
 						"attempt", attempt+1,
 						"max_retries", maxRetries)
-					
+
 					// Get fresh interface config
 					iface, ifaceErr := m.db.GetInterface(ctx, interfaceId)
 					if ifaceErr != nil {
 						return nil, fmt.Errorf("failed to get interface after IP conflict: %w", ifaceErr)
 					}
-					
+
 					// Allocate next IPs (no locks, sequence-based)
 					networks, _ := domain.CidrsFromString(iface.PeerDefNetworkStr)
 					newIps := make([]domain.Cidr, 0, len(networks))
-					
+
 					for _, network := range networks {
 						nextIP, ipErr := m.db.GetNextPeerIPForSubnet(ctx, network)
 						if ipErr != nil {
@@ -449,16 +449,16 @@ func (m Manager) CreateMultiplePeers(
 						}
 						newIps = append(newIps, nextIP)
 					}
-					
+
 					freshPeer.Interface.Addresses = newIps
 					continue
 				}
 			}
-			
+
 			// For other errors, return immediately
 			return nil, fmt.Errorf("failed to create new peer %s: %w", freshPeer.Identifier, saveErr)
 		}
-		
+
 		if saveErr != nil {
 			return nil, fmt.Errorf("failed to create peer %s: max retries exceeded: %w", freshPeer.Identifier, saveErr)
 		}


### PR DESCRIPTION
## Problem Statement

What is the problem you're trying to solve?

## Related Issue

Fixes #...

## Proposed Changes

How do you like to solve the issue and why?

## Checklist

- [ ] Commits are signed with `git commit --signoff`
- [ ] Changes have reasonable test coverage
- [ ] Tests pass with `make test`
- [ ] Helm docs are up-to-date with `make helm-docs`
