### PR TITLE
fix: remove prometheus metrics when peers deleted in sync events

### DIFF
--- a/internal/app/wireguard/wireguard.go
+++ b/internal/app/wireguard/wireguard.go
@@ -949,6 +949,12 @@ func (m Manager) handlePeerDeletedSyncEvent(peerID domain.PeerIdentifier) {
 		}
 	}
 
+	// CRITICAL: Remove Prometheus metrics for the deleted peer
+	// This prevents metrics from persisting after peer deletion
+	if m.statsCollector != nil && m.statsCollector.ms != nil {
+		m.statsCollector.ms.RemovePeerMetricsByID(string(peerID))
+	}
+
 	totalDuration := time.Since(startProcessTime)
 	slog.Info("[PEER_SYNC] deleted peer from all interfaces - COMPLETED",
 		"peer_id", peerID,
@@ -992,6 +998,13 @@ func (m Manager) handlePeerSyncedLocalEvent(peerID domain.PeerIdentifier) {
 				}
 			}
 		}
+
+		// CRITICAL: Remove Prometheus metrics for the deleted peer
+		// This prevents metrics from persisting after peer deletion
+		if m.statsCollector != nil && m.statsCollector.ms != nil {
+			m.statsCollector.ms.RemovePeerMetricsByID(string(peerID))
+		}
+
 		slog.Info("[PEER_SYNC_LOCAL] completed deletion cleanup - COMPLETED", "peer_id", peerID)
 		return
 	}


### PR DESCRIPTION
When peers are deleted through Pub/Sub sync events (TopicPeerDeletedSync and 
handlePeerSyncedLocalEvent), the metrics were not being removed from the Prometheus 
registry, causing orphaned metrics to persist indefinitely.

This commit adds explicit metrics cleanup in two critical paths:

1. handlePeerDeletedSyncEvent: called when peer deletion is synced across all cluster nodes
	- Removes Prometheus metrics before WireGuard deletion completes
	- Ensures no metric accumulation during cluster sync
	
2. handlePeerSyncedLocalEvent: called when peer not found in database (already deleted)
	- Removes metrics for peers detected as deleted
	- Prevents orphaned metrics when deletion races with sync
	
The fix uses RemovePeerMetricsByID to properly remove peer metrics from the registry,
preventing the accumulation of stale wireguard_peer_up metrics in Prometheus.

This complements the existing callback-based metrics cleanup in SavePeer and DeletePeer,
ensuring all deletion paths (direct deletion, Pub/Sub sync, retry scenarios) properly
clean up their metrics footprint.

Technical details:
- Checks m.statsCollector.ms availability before cleanup (defensive)
- Integrates with existing RemovePeerMetricsByID infrastructure
- Aligns with distributed cluster protection layers (peer existence checks)

Fixes: metrics persisting after peer deletion, 3x metric accumulation on retry events,
orphaned wireguard_peer_up label combinations in Prometheus registry