### PR TITLE
fix: preserve admin when creating default user

### DIFF
--- a/internal/app/users/user_manager.go
+++ b/internal/app/users/user_manager.go
@@ -255,7 +255,10 @@ func (m Manager) CreateUser(ctx context.Context, user *domain.User) (*domain.Use
 	}
 
 	err = m.users.SaveUser(ctx, user.Identifier, func(u *domain.User) (*domain.User, error) {
-		user.CopyCalculatedAttributes(u)
+		// When creating a new user, preserve the IsAdmin value supplied by the
+		// creator (e.g. system default admin). Do not overwrite it with the
+		// placeholder/default record created by the repo layer.
+		user.CopyCalculatedAttributesFromExisting(u)
 		return user, nil
 	})
 	if err != nil {

--- a/internal/domain/user.go
+++ b/internal/domain/user.go
@@ -187,6 +187,17 @@ func (u *User) CopyCalculatedAttributes(src *User) {
 	u.IsAdmin = src.IsAdmin // CRITICAL: protect IsAdmin from client-supplied input (CVE)
 }
 
+// CopyCalculatedAttributesFromExisting copies calculated attributes from an existing
+// record but does NOT overwrite receiver's IsAdmin flag. Use this when creating
+// a new user record to preserve the intended IsAdmin value supplied by the
+// creator (for example when the system creates the default admin).
+func (u *User) CopyCalculatedAttributesFromExisting(src *User) {
+	u.BaseModel = src.BaseModel
+	u.LinkedPeerCount = src.LinkedPeerCount
+	// Intentionally do NOT copy IsAdmin here so that newly created users
+	// (for example system-created default admin) keep their IsAdmin value.
+}
+
 // region webauthn
 
 func (u *User) WebAuthnID() []byte {


### PR DESCRIPTION
Fixes a bug where the system-created default admin could end up with `is_admin = false` after initialization, losing administrator privileges.